### PR TITLE
Added a way to expose a public key by validating a signed message.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1631,6 +1631,19 @@
         "wif": "^2.0.1"
       }
     },
+    "bitcoinjs-message": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-message/-/bitcoinjs-message-2.1.0.tgz",
+      "integrity": "sha512-xVL2YvyAJUI8ZwfNpi6Ju5zda3+QYGHTLUvISDb0VHWbsWn9Zyvd1o8XHRC/0r+DNwDIwenpXDSPl1XLCMGnMA==",
+      "requires": {
+        "bech32": "^1.1.3",
+        "bs58check": "^2.1.2",
+        "buffer-equals": "^1.0.3",
+        "create-hash": "^1.1.2",
+        "secp256k1": "^3.0.1",
+        "varuint-bitcoin": "^1.0.1"
+      }
+    },
     "bluebird": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
@@ -1715,6 +1728,19 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "browserslist": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
@@ -1753,11 +1779,21 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer-equals": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
+      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -2260,6 +2296,16 @@
         "webidl-conversions": "^4.0.2"
       }
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -2540,6 +2586,15 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -2927,12 +2982,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2947,17 +3004,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3074,7 +3134,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3086,6 +3147,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3100,6 +3162,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3107,12 +3170,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3131,6 +3196,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3211,7 +3277,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3223,6 +3290,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3344,6 +3412,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6032,6 +6101,21 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "secp256k1": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.4.1",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      }
     },
     "semver": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "@babel/polyfill": "^7.7.0",
     "bignumber.js": "^8.1.1",
     "bitcoin-address-validation": "^0.2.9",
-    "bitcoinjs-lib": "^4.0.5"
+    "bitcoinjs-lib": "^4.0.5",
+    "bitcoinjs-message": "^2.1.0"
   },
   "directories": {
     "lib": "lib"

--- a/src/message.js
+++ b/src/message.js
@@ -1,0 +1,112 @@
+/**
+ * This module a message signature validation function that also exposes the public key used to sign
+ * the message.
+ *
+ * bitcoinjs-message does not export a way to extract the
+ * public key from a signed message, even though it obtains
+ * the public key during the regular course of events of
+ * verifying a signature. Several of the following definitions
+ * are lifted verbatim from that module to support the verify
+ * implementation below that DOES expose the public key.
+
+ * @module message
+ */
+
+import {ECPair, payments, address, networks} from "bitcoinjs-lib";
+import {magicHash} from 'bitcoinjs-message';
+import createHash from 'create-hash';
+import bs58check from 'bs58check';
+import bufferEquals from 'buffer-equals';
+import bech32 from 'bech32';
+import secp256k1 from 'secp256k1';
+
+const toOutputScript = address.toOutputScript;
+const base64re=/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+
+const SEGWIT_TYPES = {
+  P2WPKH: 'p2wpkh',
+  P2SH_P2WPKH: 'p2sh(p2wpkh)'
+};
+
+function sha256 (b) {
+  return createHash('sha256')
+    .update(b)
+    .digest();
+}
+
+function hash160 (buffer) {
+  return createHash('ripemd160')
+    .update(sha256(buffer))
+    .digest();
+}
+
+function decodeSignature (buffer) {
+  if (buffer.length !== 65) throw new Error('Invalid signature length')
+
+  const flagByte = buffer.readUInt8(0) - 27;
+  if (flagByte > 15 || flagByte < 0) {
+    throw new Error('Invalid signature parameter');
+  }
+
+  return {
+    compressed: !!(flagByte & 12),
+    segwitType: !(flagByte & 8)
+      ? null
+      : !(flagByte & 4)
+        ? SEGWIT_TYPES.P2SH_P2WPKH
+        : SEGWIT_TYPES.P2WPKH,
+    recovery: flagByte & 3,
+    signature: buffer.slice(1)
+  };
+}
+
+
+/**
+ * Check to see if a message was signed by the pubkey associated
+ * with a given address, and return the pubkey if it was.
+ * @param {string} message - message signed
+ * @param {string} address - address associated with the private key that signed the message
+ * @param {string} signature - base64 encoded bitcoin message signature
+ * @returns hex encoded public key if the signature is valid, null otherwise
+ */
+export function verifyPublicKey(message, address, signature, messagePrefix) {
+  if (!Buffer.isBuffer(signature)) signature = Buffer.from(signature, 'base64')
+
+  const parsed = decodeSignature(signature);
+  const hash = magicHash(message, messagePrefix);
+  const publicKey = secp256k1.recover(
+    hash,
+    parsed.signature,
+    parsed.recovery,
+    parsed.compressed
+  );
+  const publicKeyHash = hash160(publicKey)
+  let actual, expected;
+
+  if (parsed.segwitType) {
+    if (parsed.segwitType === SEGWIT_TYPES.P2SH_P2WPKH) {
+      const redeemScript = Buffer.concat([
+        Buffer.from('0014', 'hex'),
+        publicKeyHash
+      ]);
+      const redeemScriptHash = hash160(redeemScript)
+      actual = redeemScriptHash;
+      expected = bs58check.decode(address).slice(1);
+    } else if (parsed.segwitType === SEGWIT_TYPES.P2WPKH) {
+      const result = bech32.decode(address);
+      const data = bech32.fromWords(result.words.slice(1));
+      actual = publicKeyHash;
+      expected = Buffer.from(data);
+    }
+  } else {
+    actual = publicKeyHash
+    expected = bs58check.decode(address).slice(1);
+  }
+
+  if(bufferEquals(actual, expected)) {
+  	return publicKey.toString('hex');
+  } else {
+    return null;
+  }
+}
+


### PR DESCRIPTION
Currently only works for p2pkh addresses. 

This makes it possible to use caravan to create multisig addresses that include OpenDime keys as part of the signature. (Spending protocol still TBD.) 