### PR TITLE
Option to not validate output amount greater than input amount

### DIFF
--- a/src/transactions.js
+++ b/src/transactions.js
@@ -1,4 +1,4 @@
-/** 
+/**
  * This module provides validation messages related to transactions.
  * @module transactions
  */
@@ -68,7 +68,7 @@ export function validateFeeBTC(feeBTCString, inputsTotalSats) {
 /**
  * Provide a validation message for a given BTC output amount
  * @param {string} amountString - BTC output amount
- * @param {BigNumber} inputsTotalSats - total satoshis being spent
+ * @param {BigNumber} [inputsTotalSats] - total satoshis being spent
  * @example
  * const out = "0.00000500";
  * const validationError = validateOutputAmountBTC(out, BigNumber(1000000));
@@ -96,7 +96,7 @@ export function validateOutputAmountBTC(amountString, inputsTotalSats) {
     return "Invalid output amount.";
   }
 
-  if (amount.isGreaterThan(satoshisToBitcoins(inputsTotalSats))) {
+  if (typeof inputsTotalSats !== 'undefined' && amount.isGreaterThan(satoshisToBitcoins(inputsTotalSats))) {
     return "Output amount is too large.";
   }
 

--- a/src/transactions.test.js
+++ b/src/transactions.test.js
@@ -8,13 +8,13 @@ describe("Test fees and rates", () => {
             const msg = validateFeeRate(feerate);
             expect(msg).toBe("Fee rate must be positive.");
         });
-    
+
         it("should properly report the validation of an excessive fee rate", () => {
             const feerate = BigNumber(1001);
             const msg = validateFeeRate(feerate);
             expect(msg).toBe("Fee rate is too high.");
         });
-    
+
         it("should not provide a validation message for a valid fee rate", () => {
             const feerate = BigNumber(5);
             const msg = validateFeeRate(feerate);
@@ -47,36 +47,69 @@ describe("Test fees and rates", () => {
     });
 
     describe('Test validateOutputAmountBTC', () => {
+        describe("Test validation with inputs provided", () => {
+            it("should properly report the validation of a negative output amount", () => {
+                const out = "-1";
+                const msg = validateOutputAmountBTC(out, BigNumber(1000000));
+                expect(msg).toBe("Output amount must be positive.");
+            });
 
-    
-        it("should properly report the validation of a negative output amount", () => {
-            const out = "-1";
-            const msg = validateOutputAmountBTC(out, BigNumber(1000000));
-            expect(msg).toBe("Output amount must be positive.");
+            it("should properly report the validation of amounts below the dust limit", () => {
+                const out = "0.00000500";
+                const msg = validateOutputAmountBTC(out, BigNumber(1000000));
+                expect(msg).toBe("Output amount is too small.");
+            });
+
+            it("should properly report the validation of a fraction of a satoshi", () => {
+                const out = "1.000000001";
+                const msg = validateOutputAmountBTC(out, BigNumber("1000000000"));
+                expect(msg).toBe("Invalid output amount.");
+            });
+
+            it("should properly report the validation of spending more than the input amount provided", () => {
+                const out = "1.00000000";
+                const msg = validateOutputAmountBTC(out, BigNumber("10000000"));
+                expect(msg).toBe("Output amount is too large.");
+            });
+
+            it("should not provide a validation message for a valid output amount", () => {
+                const out = "0.00090000";
+                const msg = validateOutputAmountBTC(out, BigNumber(1000000));
+                expect(msg).toBe("");
+            });
+        })
+
+        describe("Test validation with no inputs provided", () => {
+            it("should ignore output larger than input if input not provided", () => {
+                const out = "1.00000000";
+                const msg = validateOutputAmountBTC(out);
+                expect(msg).toBe("");
+            })
+
+            it("should properly report the validation of a negative output amount", () => {
+                const out = "-1";
+                const msg = validateOutputAmountBTC(out);
+                expect(msg).toBe("Output amount must be positive.");
+            });
+
+            it("should properly report the validation of amounts below the dust limit", () => {
+                const out = "0.00000500";
+                const msg = validateOutputAmountBTC(out);
+                expect(msg).toBe("Output amount is too small.");
+            });
+
+            it("should properly report the validation of a fraction of a satoshi", () => {
+                const out = "1.000000001";
+                const msg = validateOutputAmountBTC(out);
+                expect(msg).toBe("Invalid output amount.");
+            });
+
+            it("should not provide a validation message for a valid output amount", () => {
+                const out = "0.00090000";
+                const msg = validateOutputAmountBTC(out);
+                expect(msg).toBe("");
+            });
         });
 
-        it("should properly report the validation of amounts below the dust limit", () => {
-            const out = "0.00000500";
-            const msg = validateOutputAmountBTC(out, BigNumber(1000000));
-            expect(msg).toBe("Output amount is too small.");
-        });
-
-        it("should properly report the validation of a fraction of a satoshi", () => {
-            const out = "1.000000001";
-            const msg = validateOutputAmountBTC(out, BigNumber("1000000000"));
-            expect(msg).toBe("Invalid output amount.");
-        });
-
-        it("should properly report the validation of spending more than the input amount provided", () => {
-            const out = "1.00000000";
-            const msg = validateOutputAmountBTC(out, BigNumber("10000000"));
-            expect(msg).toBe("Output amount is too large.");
-        });
-
-        it("should not provide a validation message for a valid output amount", () => {
-            const out = "0.00090000";
-            const msg = validateOutputAmountBTC(out, BigNumber(1000000));
-            expect(msg).toBe("");
-        });
     });
 });


### PR DESCRIPTION
This is a valid state for a wallet doing coin selection, when a user adds outputs and before the wallet does coin selection, the output amount will be more than the input amount until enough coins are selected.

By making `inputsTotalSats` and optional parameter to `validateOutputAmountBTC` the undesired message is ignored if `inputsTotalSats` is omitted.