### PR TITLE
xpub utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2906,7 +2906,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2927,12 +2928,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2947,17 +2950,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3074,7 +3080,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3086,6 +3093,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3100,6 +3108,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3107,12 +3116,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3131,6 +3142,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3211,7 +3223,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3223,6 +3236,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3308,7 +3322,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3344,6 +3359,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3363,6 +3379,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3406,12 +3423,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1214,9 +1214,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-globals": {
@@ -1230,9 +1230,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -3538,9 +3538,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+      "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -4726,9 +4726,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "klaw": {
@@ -6744,9 +6744,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
   },
   "scripts": {
     "compile": "babel -d lib/ src/",
+    "compile:watch": "babel --watch -d lib/ src/",
     "prepublish": "npm run compile",
     "pretest": "npm run compile",
     "prepare": "npm run compile",
     "test": "jest lib",
+    "test:watch": "jest --watch src",
     "docs": "./bin/build-docs.sh",
     "lint": "eslint src"
   },

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
     "@babel/cli": "^7.7.0",
     "@babel/core": "^7.7.2",
     "@babel/preset-env": "^7.7.1",
+    "bs58": "^4.0.1",
+    "eslint": "^6.6.0",
+    "eslint-plugin-jest": "^23.0.3",
     "jest": "^24.9.0",
     "jest-junit": "^9.0.0",
     "jsdoc": "^3.6.3",
-    "mocha": "^6.2.2",
-    "eslint": "^6.6.0",
-    "eslint-plugin-jest": "^23.0.3"
+    "mocha": "^6.2.2"
   },
   "scripts": {
     "compile": "babel -d lib/ src/",

--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -51,6 +51,7 @@ const NODES = {
   "m/45'/0'/0'/0": {
     pub: "03b32dc780fba98db25b4b72cf2b69da228f5e10ca6aa8f46eabe7f9fe22c994ee",
     xpub: "xpub6EW9kGJQLjEGWpuKjViLuEw3pkNX5k2DzXhM3ctfHawh12aLXnrzYuRcvwTfv2VD2a8uzFCDJfLnrrD9Z46NbLyPHUQbbb4QyxKjf6c1gh4",
+    tpub: "tpubDEsnGW8641Bind6BBghS7AGR9sUB58XHYAHeQAwodVhakKF3c1i5hM6TAyYTSXSSpUfpbpi5qmAqZ2hkwuwcUnRgM59uH7ieZuv9RAEJ5Rp",
     chaincode: "4522d0dc37c97548c43adc8fbbe285eea27921e8437562574d13c013e85c0fd3",
     fingerprint: 2213579839,
   },

--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -42,13 +42,24 @@ const BIP39_PHRASE = ['merge', 'alley', 'lucky', 'axis', 'penalty', 'manage', 'l
 
 const NODES = {
   "m/45'/0'/0'": {
+    pub: "0387cb4929c287665fbda011b1afbebb0e691a5ee11ee9a561fcd6adba266afe03",
     xpub: "xpub6CCHViYn5VzKFqrKjAzSSqP8XXSU5fEC6ZYSncX5pvSKoRLrPDcF8cEaZkrQvvnuwRUXeKVjoGmAqvbwVkNBFLaRiqcdVhWPyuShUrbcZsv",
     tpub: "tpubDCZv1xNTnmwmXe3BBMyXekiVreY853jFeC8k9AaEAqCDYi1ZTSTLH3uQonwCTRk9jL1SFu1cLNbDY76YtcDR8n2inSMwBEAdZs37EpYS9px",
+    chaincode: "470bb034dbc8e7b5f5c0b19f747e3e768f0cc9ff298361b2741e1b7fd70d376d",
+    fingerprint: 1240308660,
+  },
+  "m/45'/0'/0'/0": {
+    pub: "03b32dc780fba98db25b4b72cf2b69da228f5e10ca6aa8f46eabe7f9fe22c994ee",
+    xpub: "xpub6EW9kGJQLjEGWpuKjViLuEw3pkNX5k2DzXhM3ctfHawh12aLXnrzYuRcvwTfv2VD2a8uzFCDJfLnrrD9Z46NbLyPHUQbbb4QyxKjf6c1gh4",
+    chaincode: "4522d0dc37c97548c43adc8fbbe285eea27921e8437562574d13c013e85c0fd3",
+    fingerprint: 2213579839,
   },
   "m/45'/0'/0'/0/0": {
     pub: "03102f0df5e34ffa1178a5310952221b8e26b3e761a9e328832c750a2de252f21a",
     xpub: "xpub6FjSpitFpSJB9BpSVwp3eJzhpaQFLbLefD1f3qaGRmok2Z2FDeSNsy5CL9TLwM3HpcV2kAyTNf2W1uUXs1jbeXGWjdWnsaqnUQ9PyWAYVhQ",
-    tpub: "tpubDG75LxhwXiFdQz1Hx8o8rEL59hVuKyqiCqbxQPdQmgZdmqgxHsHU2Qk2aBY8TqzXcX1wMkVKukrYi5y9FsaqXxiooEG6Z7W24MjojRNcVtA"
+    tpub: "tpubDG75LxhwXiFdQz1Hx8o8rEL59hVuKyqiCqbxQPdQmgZdmqgxHsHU2Qk2aBY8TqzXcX1wMkVKukrYi5y9FsaqXxiooEG6Z7W24MjojRNcVtA",
+    chaincode: "4522d0dc37c97548c43adc8fbbe285eea27921e8437562574d13c013e85c0fd3",
+    fingerprint: 724365675,
   },
   "m/45'/0'/4'": {
     xpub: "xpub6CCHViYn5VzKSmKD9cK9LBDPz9wBLV7owXJcNDioETNvhqhVtj3ABnVUERN9aV1RGTX9YpyPHnC4Ekzjnr7TZthsJRBiXA4QCeXNHEwxLab",

--- a/src/keys.js
+++ b/src/keys.js
@@ -6,10 +6,11 @@
  */
 
 import {ECPair} from "bitcoinjs-lib";
+import bip32 from "bip32";
 
 import {validateHex, toHexString, hash160} from "./utils";
-import {TESTNET, networkData} from "./networks";
-const bip32 = require('bip32');
+import {bip32PathToSequence} from "./paths"
+import {TESTNET, networkData, MAINNET} from "./networks";
 
 /**
  * Validate the given extended public key.
@@ -167,7 +168,28 @@ export function deriveChildExtendedPublicKey(extendedPublicKey, bip32Path, netwo
 }
 
 /**
- * Gets fingerprint for a given pubkey. This is useful for generating xpubs
+ * Check if a given pubkey is compressed or not by checking its length
+ * and the possible prefixes
+ * @param {string | Buffer} pubkey 
+ * @returns {boolean}
+ * @example
+ * import {isKeyCompressed} from "unchained-bitcoin"
+ * const uncompressed = "0487cb4929c287665fbda011b1afbebb0e691a5ee11ee9a561fcd6adba266afe03f7c55f784242305cfd8252076d038b0f3c92836754308d06b097d11e37bc0907"
+ * const compressed = "0387cb4929c287665fbda011b1afbebb0e691a5ee11ee9a561fcd6adba266afe03"
+ * console.log(isKeyCompressed(uncompressed)) // false
+ * console.log(isKeyCompressed(compressed)) // true
+ */
+export function isKeyCompressed(pubkey) {
+  if (!Buffer.isBuffer(pubkey))
+    pubkey = Buffer.from(pubkey, 'hex')
+
+  if (pubkey.length === 33 && (pubkey[0] === 2 || pubkey[0] === 3)) 
+    return true
+  return false
+}
+
+/**
+ * Get fingerprint for a given pubkey. This is useful for generating xpubs
  * which need the fingerprint of the parent pubkey. If not a compressed key
  * then this function will attempt to compress it.
  * @param {string} pubkey - pubkey to derive fingerprint from
@@ -179,10 +201,37 @@ export function deriveChildExtendedPublicKey(extendedPublicKey, bip32Path, netwo
  */
 export function getFingerprintFromPublicKey(pubkey) {
   // compress the key if it is not compressed
-  if (pubkey.length !== 66 && (pubkey[1] !== 2 || pubkey[1] !== 3)) {
+  if (!isKeyCompressed(pubkey)) {
     pubkey = compressPublicKey(pubkey) 
   }
   const pubkeyBuffer = Buffer.from(pubkey, 'hex')
   const hash = hash160(pubkeyBuffer)
   return ((hash[0] << 24) | (hash[1] << 16) | (hash[2] << 8) | hash[3]) >>> 0;
+}
+
+/**
+ * Derive base58 encoded xpub given known information about
+ * BIP32 Wallet Node
+ * @param {string} bip32Path 
+ * @param {string} pubkey 
+ * @param {string} chaincode 
+ * @param {string} fingerprint - fingerprint of parent public key
+ * @param {string} network - mainnet or testnet
+ * @returns {string} base58 encoded extended public key (xpub or tpub)
+ */
+export function deriveExtendedPublicKey(bip32Path, pubkey, chaincode, fingerprint, network = MAINNET) {
+  if (!isKeyCompressed(pubkey)) 
+    pubkey = compressPublicKey(pubkey)
+  
+  // get the hd wallet node and fill in missing properties
+  const node = bip32.fromPublicKey(Buffer.from(pubkey, 'hex'),
+    Buffer.from(chaincode, 'hex'), networkData(network));
+  
+   // extended key fingerprint is from the parent pubkey
+  node.parentFingerprint = fingerprint
+  node.depth = bip32Path.split("/").length - 1;
+  const sequence = bip32PathToSequence(bip32Path);
+  node.index = sequence.slice(-1)[0];
+  node.path = bip32Path;
+  return node.toBase58()
 }

--- a/src/keys.test.js
+++ b/src/keys.test.js
@@ -1,14 +1,18 @@
+import bs58 from 'bs58'
+
 import { 
     validateExtendedPublicKey, 
     validatePublicKey, 
     compressPublicKey, 
     deriveChildPublicKey, 
     deriveChildExtendedPublicKey,
+    getFingerprintFromPublicKey,
 } from './keys';
 
 import { TESTNET, MAINNET } from './networks';
 
 import {TEST_FIXTURES} from "./fixtures";
+import { bitcoinsToSatoshis } from './utils';
 
 const NODES = TEST_FIXTURES.nodes;
 
@@ -174,5 +178,19 @@ describe("keys", () => {
     });
 
   });
+
+  describe('getFingerprintFromPublicKey', () => {
+    it('derives the correct fingerprint from a given key', () => {
+      const node = NODES["m/45'/0'/0'/0"]
+      const parentNode = NODES["m/45'/0'/0'"]
+      const fingerprint = getFingerprintFromPublicKey(parentNode.pub)
+      const decodedXpub = bs58.decode(node.xpub).toString('hex')
+      console.log('fingerprint:', fingerprint)
+      // the child node should have its parent's fingerprint in the xpub
+      expect(node.fingerprint).toEqual(fingerprint)
+      // we should also be able to find the fingerprint in the decoded xpub
+      expect(decodedXpub).toContain(fingerprint.toString(16))
+    })
+  })
 
 });

--- a/src/paths.js
+++ b/src/paths.js
@@ -5,10 +5,10 @@
  * @module paths
  */
 
-import {MAINNET} from "./networks";
-import {P2SH} from "./p2sh";
-import {P2SH_P2WSH} from "./p2sh_p2wsh";
-import {P2WSH} from "./p2wsh";
+import { MAINNET } from "./networks";
+import { P2SH } from "./p2sh";
+import { P2SH_P2WSH } from "./p2sh_p2wsh";
+import { P2WSH } from "./p2wsh";
 
 const HARDENING_OFFSET = Math.pow(2, 31);
 
@@ -113,29 +113,29 @@ export function validateBIP32Path(pathString, options) {
     return "BIP32 path cannot be blank.";
   }
 
-  if (! pathString.match(BIP32_PATH_REGEX)) {
+  if (!pathString.match(BIP32_PATH_REGEX)) {
     return "BIP32 path is invalid.";
   }
 
   if (options && options.mode === 'hardened') {
-    if (! pathString.match(BIP32_HARDENED_PATH_REGEX)) {
+    if (!pathString.match(BIP32_HARDENED_PATH_REGEX)) {
       return "BIP32 path must be fully-hardened.";
     }
   }
 
   if (options && options.mode === 'unhardened') {
-    if (! pathString.match(BIP32_UNHARDENED_PATH_REGEX)) {
+    if (!pathString.match(BIP32_UNHARDENED_PATH_REGEX)) {
       return "BIP32 path cannot include hardened segments.";
     }
   }
-  
+
   const segmentStrings = pathString.toLowerCase().split('/');
 
   return validateBIP32PathSegments(segmentStrings.slice(1));
 }
 
 function validateBIP32PathSegments(segmentStrings) {
-  for (let i=0; i<segmentStrings.length; i++) {
+  for (let i = 0; i < segmentStrings.length; i++) {
     const segmentString = segmentStrings[i];
     const error = validateBIP32PathSegment(segmentString);
     if (error !== '') { return error; }
@@ -147,7 +147,7 @@ function validateBIP32PathSegment(segmentString) {
   if (segmentString === null || segmentString === undefined || segmentString === '') {
     return "BIP32 path segment cannot be blank.";
   }
-  
+
   let numberString, hardened;
   if (segmentString.substr(segmentString.length - 1) === "'") {
     numberString = segmentString.substr(0, segmentString.length - 1);
@@ -163,7 +163,7 @@ function validateBIP32PathSegment(segmentString) {
   let number;
   try {
     number = parseInt(numberString, 10);
-  } catch(parseError) {
+  } catch (parseError) {
     // shouldn't reach here b/c we already applied a regex check
     return numberError;
   }
@@ -205,14 +205,14 @@ function validateBIP32PathSegment(segmentString) {
 export function multisigBIP32Root(addressType, network) {
   const coinPath = (network === MAINNET ? "0'" : "1'");
   switch (addressType) {
-  case P2SH:
-    return `m/45'/${coinPath}/0'`;
-  case P2SH_P2WSH:
-    return `m/48'/${coinPath}/0'/1'`;
-  case P2WSH:
-    return `m/48'/${coinPath}/0'/2'`;
-  default:
-    return null;
+    case P2SH:
+      return `m/45'/${coinPath}/0'`;
+    case P2SH_P2WSH:
+      return `m/48'/${coinPath}/0'/1'`;
+    case P2WSH:
+      return `m/48'/${coinPath}/0'/2'`;
+    default:
+      return null;
   }
 }
 
@@ -235,4 +235,20 @@ export function multisigBIP32Path(addressType, network, relativePath) {
     return root + `/${relativePath || "0"}`;
   }
   return null;
+}
+
+/**
+ * Get the path of the parent of the given path
+ * @param {string} bip32Path 
+ * @returns {string} parent path
+ * @example
+ * import {getParentPath} from "unchained-bitcoin";
+ * console.log(getParentPath("m/45'/0'/0'/0"); // m/45'/0'/0'
+ */
+export function getParentPath(bip32Path) {
+  // first validate the input
+  let validated = validateBIP32Path(bip32Path)
+  if (validated.length) return validated
+  // then slice off then last item in the path
+  return bip32Path.split("/").slice(0, -1).join("/");
 }

--- a/src/paths.js
+++ b/src/paths.js
@@ -5,10 +5,10 @@
  * @module paths
  */
 
-import { MAINNET } from "./networks";
-import { P2SH } from "./p2sh";
-import { P2SH_P2WSH } from "./p2sh_p2wsh";
-import { P2WSH } from "./p2wsh";
+import {MAINNET} from "./networks";
+import {P2SH} from "./p2sh";
+import {P2SH_P2WSH} from "./p2sh_p2wsh";
+import {P2WSH} from "./p2wsh";
 
 const HARDENING_OFFSET = Math.pow(2, 31);
 
@@ -205,14 +205,14 @@ function validateBIP32PathSegment(segmentString) {
 export function multisigBIP32Root(addressType, network) {
   const coinPath = (network === MAINNET ? "0'" : "1'");
   switch (addressType) {
-    case P2SH:
-      return `m/45'/${coinPath}/0'`;
-    case P2SH_P2WSH:
-      return `m/48'/${coinPath}/0'/1'`;
-    case P2WSH:
-      return `m/48'/${coinPath}/0'/2'`;
-    default:
-      return null;
+  case P2SH:
+    return `m/45'/${coinPath}/0'`;
+  case P2SH_P2WSH:
+    return `m/48'/${coinPath}/0'/1'`;
+  case P2WSH:
+    return `m/48'/${coinPath}/0'/2'`;
+  default:
+    return null;
   }
 }
 

--- a/src/paths.test.js
+++ b/src/paths.test.js
@@ -1,14 +1,15 @@
 import {
   hardenedBIP32Index,
-  bip32PathToSequence, 
-  bip32SequenceToPath, 
+  bip32PathToSequence,
+  bip32SequenceToPath,
   validateBIP32Path,
   multisigBIP32Root,
   multisigBIP32Path,
+  getParentPath,
 } from './paths';
-import {P2SH} from "./p2sh";
-import {P2SH_P2WSH} from "./p2sh_p2wsh";
-import {P2WSH} from "./p2wsh";
+import { P2SH } from "./p2sh";
+import { P2SH_P2WSH } from "./p2sh_p2wsh";
+import { P2WSH } from "./p2wsh";
 import {
   TESTNET,
   MAINNET,
@@ -81,12 +82,12 @@ describe('paths', () => {
 
     it("enforces mode=hardened if asked", () => {
       expect(validateBIP32Path("m/45'/0")).toEqual("");
-      expect(validateBIP32Path("m/45'/0", {mode: "hardened"})).toMatch(/fully-hardened/i);
+      expect(validateBIP32Path("m/45'/0", { mode: "hardened" })).toMatch(/fully-hardened/i);
     });
 
     it("enforces mode=unhardened if asked", () => {
       expect(validateBIP32Path("m/45'/0")).toEqual("");
-      expect(validateBIP32Path("m/45'/0", {mode: "unhardened"})).toMatch(/cannot include hardened/i);
+      expect(validateBIP32Path("m/45'/0", { mode: "unhardened" })).toMatch(/cannot include hardened/i);
     });
 
   });
@@ -116,7 +117,7 @@ describe('paths', () => {
   });
 
   describe('multisigBIP32Path', () => {
-    
+
     it("returns a BIP32 path with the correct root for each combination of address type, network, and relative path", () => {
       expect(multisigBIP32Path(P2SH, MAINNET, "1")).toEqual("m/45'/0'/0'/1");
       expect(multisigBIP32Path(P2SH, TESTNET, "1'/2'")).toEqual("m/45'/1'/0'/1'/2'");
@@ -128,7 +129,20 @@ describe('paths', () => {
       expect(multisigBIP32Path(P2SH, MAINNET)).toEqual("m/45'/0'/0'/0");
       expect(multisigBIP32Path(P2SH, TESTNET)).toEqual("m/45'/1'/0'/0");
     });
-    
+
   });
 
+  describe('getParentPath', () => {
+    it("validates and returns the correct BIP32 parent path for each given path", () => {
+      expect(getParentPath("")).toMatch(/cannot be blank/i);
+      expect(getParentPath("foo")).toMatch(/is invalid/i);
+      expect(getParentPath("/45")).toMatch(/is invalid/i);
+      const validPaths = ["m/45'", "m/45'/0'", "m/45'/0'/0'", "m/45'/0'/0'/0", "m/45'/0'/0'/0/0"]
+      for (let i = validPaths.length - 1; i > 0; i--) {
+        const expected = validPaths[i - 1]
+        const actual = getParentPath(validPaths[i])
+        expect(actual).toMatch(expected)
+      }
+    })
+  })
 });

--- a/src/paths.test.js
+++ b/src/paths.test.js
@@ -7,9 +7,9 @@ import {
   multisigBIP32Path,
   getParentPath,
 } from './paths';
-import { P2SH } from "./p2sh";
-import { P2SH_P2WSH } from "./p2sh_p2wsh";
-import { P2WSH } from "./p2wsh";
+import {P2SH} from "./p2sh";
+import {P2SH_P2WSH} from "./p2sh_p2wsh";
+import {P2WSH} from "./p2wsh";
 import {
   TESTNET,
   MAINNET,

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,7 @@
  */
 
 import BigNumber from "bignumber.js";
+import bitcoin from "bitcoinjs-lib";
 
 /**
  * Converts a byte array to its hex representation.
@@ -20,7 +21,7 @@ import BigNumber from "bignumber.js";
  * 
  */
 export function toHexString(byteArray) {
-  return Array.prototype.map.call(byteArray, function(byte) {
+  return Array.prototype.map.call(byteArray, function (byte) {
     return ('0' + (byte & 0xFF).toString(16)).slice(-2);
   }).join('');
 }
@@ -97,3 +98,13 @@ export function bitcoinsToSatoshis(btc) {
 }
 
 export const ZERO = BigNumber(0);
+
+/**
+ * Given a buffer as a digest, pass through sha256 and ripemd160
+ * hash functions. Returns the result
+ * @param {Buffer} buf - buffer to get hash160 of
+ * @returns {Buffer}
+ */
+export function hash160(buf) {
+  return bitcoin.crypto.ripemd160(bitcoin.crypto.sha256(buf))
+}

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,5 +1,12 @@
 import BigNumber from "bignumber.js";
-import { validateHex, toHexString, satoshisToBitcoins, bitcoinsToSatoshis } from './utils';
+import {
+  validateHex,
+  toHexString,
+  satoshisToBitcoins,
+  bitcoinsToSatoshis,
+  hash160
+} from './utils';
+import crypto from 'crypto'
 
 describe("utils", () => {
 
@@ -105,6 +112,13 @@ describe("utils", () => {
 
   });
 
+  describe('hash160', () => {
+    it('should take a buffer and hash it with sha256 and ripemd160', () => {
+      const val = Buffer.from('a2bc6de234a4b2fe10fe582f29c39de52b8161624ef310ca6cccff5d6d7d591a', 'hex')
+      const expected = Buffer.from('d06d0dadca1f9cf3aedd5514e0669c2fffa7bc81', 'hex')
+      expect(hash160(val)).toEqual(expected)
+    })
+  })
 });
 
 


### PR DESCRIPTION
These are generalized utilities that have been refactored out of the ledger wallet update https://github.com/unchained-capital/unchained-wallets/pull/17

New utilities:
- `isKeyCompressed`
- `getFingerprintFromPublicKey`
- `deriveExtendedPublicKey`
- `getParentPath`
- `hash160`

these are all used for exporting xpubs from a ledger which does not give a straightforward way of retrieving xpubs out of the box and so require some data manipulation and two rounds of requests from the device (need to get the pubkey from parent node in addition to request at derivation path). These updates handle all data manipulation while ledger device interactions are done in `unchained-wallets` PR 17