### PR TITLE
Adds `fingerprintToFixedLengthHex` function and tests

### DIFF
--- a/src/keys.js
+++ b/src/keys.js
@@ -419,11 +419,14 @@ export function isKeyCompressed(_pubkey) {
  * which need the fingerprint of the parent pubkey. If not a compressed key
  * then this function will attempt to compress it.
  * @param {string} _pubkey - pubkey to derive fingerprint from
- * @returns {string} fingerprint
+ * @returns {number} fingerprint
  * @example
- * import {getFingerprintFromPublicKey, compressPublicKey} from "unchained-bitcoin"
+ * import {getFingerprintFromPublicKey} from "unchained-bitcoin"
  * const pubkey = "03b32dc780fba98db25b4b72cf2b69da228f5e10ca6aa8f46eabe7f9fe22c994ee"
- * console.log(getFingerprintFromPublicKey(pubkey)) // 2213579839
+ * console.log(getFingerprintFromPublicKey(pubkey)) // 724365675
+ *
+ * const uncompressedPubkey = "04dccdc7fc599ed379c415fc2bb398b1217f0142af23692359057094ce306cd3930e6634c71788b9ed283219ca2fea102aaf137cd74e025cce97b94478a02029cf"
+ * console.log(getFingerprintFromPublicKey(uncompressedPubkey)) // 247110101
  */
 export function getFingerprintFromPublicKey(_pubkey) {
   let pubkey = _pubkey;
@@ -434,6 +437,25 @@ export function getFingerprintFromPublicKey(_pubkey) {
   const pubkeyBuffer = Buffer.from(pubkey, "hex");
   const hash = hash160(pubkeyBuffer);
   return ((hash[0] << 24) | (hash[1] << 16) | (hash[2] << 8) | hash[3]) >>> 0;
+}
+
+/**
+ * Take a fingerprint and return a zero-padded, hex-formatted string
+ * that is exactly eight characters long.
+ *
+ * @param {number} xfp the fingerprint
+ * @returns {string} zero-padded, fixed-length hex xfp
+ *
+ * @example
+ * import {fingerprintToFixedLengthHex} from "unchained-bitcoin"
+ * const pubkeyFingerprint = 724365675
+ * console.log(fingerprintToFixedLengthHex(pubkeyFingerprint)) // 2b2cf16b
+ *
+ * const uncompressedPubkeyFingerprint = 247110101
+ * console.log(fingerprintToFixedLengthHex(uncompressedPubkeyFingerprint)) // 0eba99d5
+ */
+export function fingerprintToFixedLengthHex(xfp) {
+  return (xfp + 0x100000000).toString(16).substr(-8);
 }
 
 /**

--- a/src/keys.test.js
+++ b/src/keys.test.js
@@ -14,6 +14,7 @@ import {
   validatePrefix,
   EXTENDED_PUBLIC_KEY_VERSIONS,
   ExtendedPublicKey,
+  fingerprintToFixedLengthHex,
 } from "./keys";
 
 import { TESTNET, MAINNET } from "./networks";
@@ -383,6 +384,28 @@ describe("keys", () => {
       expect(decodedXpub).toContain(fingerprint.toString(16));
     });
   });
+
+  describe("fingerprintToFixedLengthHex", () => {
+    it("returns 4-byte zero-padded hex string", () => {
+      const hexOutputs = {
+        '00000007': 7,
+        '0000007b': 123,
+        '00000943': 2371,
+        '0000d2bb': 53947,
+        '0004ec4f': 322639,
+        '00f4a5bc': 16033212,
+        '01808a52': 25201234,
+        '32a7ae1c': 849849884,
+        'fa8cae68': 8498490984, // should be 1fa8cae68 but truncated front 1
+      };
+
+      for (const [xfpHex, xfpNumber] of Object.entries(hexOutputs)) {
+        const hexFingerprint = fingerprintToFixedLengthHex(xfpNumber);
+        expect(hexFingerprint.length).toEqual(8);
+        expect(hexFingerprint).toEqual(xfpHex)
+      }
+    })
+  })
 
   describe("deriveExtendedPublicKey", () => {
     it("derives a valid bip32 node with all matching HD wallet properties", () => {


### PR DESCRIPTION
Given the existing fingerprint functionality, here we add a function to output a fixed-length, zero-padded, hex string that is exactly eight characters in length.

Unit tests included. Updated some of the jsdocs as well.