### PR TITLE
Cobo Vault integration

### DIFF
--- a/src/keys.js
+++ b/src/keys.js
@@ -215,7 +215,7 @@ export class ExtendedPublicKey extends Struct {
     this.index = br.readU32BE();
     this.chaincode = br.readString(32, "hex");
     this.pubkey = br.readString(33, "hex");
-
+    this.base58String = this.toBase58()
     return this;
   }
 }


### PR DESCRIPTION
Missing base58String when generate ExtendedPublicKey from base58 which will cause exception when generating Braid for multisig usage