### PR TITLE
Fixes a validation issue when creating the Signature Buffer

### DIFF
--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -1,7 +1,7 @@
 /**
  * This module provides useful test fixtures.
  *
- * All test fixtures are derived from the same BIP39 seed phrase
+ * Most test fixtures are derived from the same BIP39 seed phrase
  * (which is also included as a fixture).
  *
  * Test transactions are multisig which allows them to have one of the

--- a/src/signatures.js
+++ b/src/signatures.js
@@ -88,12 +88,25 @@ export function validateMultisigSignature(network, inputs, outputs, inputIndex, 
   return false;
 }
 
+/**
+ * This function takes a DER encoded signature and returns it without the SIGHASH_BYTE
+ * @param {string} signature inputSignature which includes DER encoding bytes and may include SIGHASH byte
+ * @return {string} signature_no_sighash with sighash_byte removed
+ */
 export function signatureNoSighashType(signature) {
   const len = parseInt(signature.slice(2,4), 16);
   if (len === (signature.length - 4) / 2) return signature;
   else return signature.slice(0, -2);
 }
 
+/**
+ * Returns the multisig Signature Hash for an input at inputIndex
+ * @param {module:networks.NETWORKS} network - bitcoin network
+ * @param {module:inputs.MultisigTransactionInput[]} inputs - multisig transaction inputs
+ * @param {module:outputs.TransactionOutput[]} outputs - transaction outputs
+ * @param {number} inputIndex - the index where the input appears in the transaction
+ * @return {Buffer} unsignedTransaction hash in a Buffer for consumption by ECPair.verify
+ */
 function multisigSignatureHash(network, inputs, outputs, inputIndex) {
   const unsignedTransaction = unsignedMultisigTransaction(network, inputs, outputs);
   const input = inputs[inputIndex];
@@ -104,18 +117,33 @@ function multisigSignatureHash(network, inputs, outputs, inputIndex) {
   }
 }
 
+/**
+ * Create a signature buffer that can be passed to ECPair.verify
+ * @param {string} signature - a DER encoded signature string
+ * @return {Buffer} signatureBuffer - correctly allocated buffer with relevant r, S information from the encoded signature
+ */
 function multisigSignatureBuffer(signature) {
   const encodedSignerInputSignatureBuffer = Buffer.from(signature, 'hex');
   const decodedSignerInputSignatureBuffer = bip66.decode(encodedSignerInputSignatureBuffer);
   const {r, s} = decodedSignerInputSignatureBuffer;
-  // Ignore the leading 0 if r is 33 bytes
-  let rToUse = r;
-  if (r.byteLength > 32) {
-    rToUse = r.slice(1);
-  }
+  // The value returned from the decodedSignerInputSignatureBuffer has
+  // a few edge cases that need to be handled properly. There exists a mismatch between the
+  // DER serialization and the ECDSA requirements, namely:
+  //   DER says that its highest bit states polarity (positive/negative)
+  //   ECDSA says no negatives, only positives.
+  // So in the case where DER would result in a negative, a one-byte 0x00 is added to the value
+  // NOTE: this can happen on r and on S.
+
+  // See https://transactionfee.info/charts/bitcoin-script-ecdsa-length/ for more information
+
+  // Truncate the leading 0x00 if r or S is 33 bytes long
+  let rToUse = r.byteLength > 32 ? r.slice(1) : r;
+  // Technically, this could be done but extremely unlikely in the current era.
+  // let sToUse = s.byteLength > 32 ? s.slice(1) : s;
 
   const signatureBuffer = Buffer.alloc(64);
-  signatureBuffer.set(Buffer.from(rToUse), 0);
-  signatureBuffer.set(Buffer.from(s), 32);
+  // r/s bytelength could be < 32, in which case, zero padding needed
+  signatureBuffer.set(Buffer.from(rToUse), 32 - rToUse.byteLength);
+  signatureBuffer.set(Buffer.from(s), 64 - s.byteLength);
   return signatureBuffer;
 }


### PR DESCRIPTION
An `S` value can be fewer than 32 bytes in length, in which case it needs to be zero padded when added to signature buffer to allow for proper validation. This is a relatively rare case, but we ran into it when testing.