### PR TITLE
extend validatePublicKey to accept addressType parameter

### DIFF
--- a/src/keys.js
+++ b/src/keys.js
@@ -332,7 +332,7 @@ export function validateExtendedPublicKey(xpubString, network) {
  * - Must be a valid BIP32 public key.
  *
  * @param {string} pubkeyHex - (compressed) public key in hex
- * @param {string} addressType - one of P2SH, P2SH-P2WSH, P2WSH
+ * @param {string} addressType - (optional) one of P2SH, P2SH-P2WSH, P2WSH
  * @returns {string} empty if valid or corresponding validation message if not
  * @example
  * import {validatePublicKey} from "unchained-bitcoin";
@@ -342,7 +342,7 @@ export function validateExtendedPublicKey(xpubString, network) {
  * console.log(validatePublicKey("03b32dc780fba98db25b4b72cf2b69da228f5e10ca6aa8f46eabe7f9fe22c994ee")); // ""
  * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53")); // ""
  * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53", "P2SH")); // ""
- * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53", "P2WSH")); // "P2WSH doesnt support uncompressed public key."
+ * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53", "P2WSH")); // "P2WSH does not support uncompressed public key."
  */
 export function validatePublicKey(pubkeyHex, addressType) {
   if (pubkeyHex === null || pubkeyHex === undefined || pubkeyHex === "") {
@@ -362,7 +362,6 @@ export function validatePublicKey(pubkeyHex, addressType) {
 
   if (
     !isKeyCompressed(pubkeyHex) &&
-    addressType &&
     [P2SH_P2WSH, P2WSH].includes(addressType)
   ) {
     return `${addressType} does not support uncompressed public keys.`;

--- a/src/keys.js
+++ b/src/keys.js
@@ -332,7 +332,7 @@ export function validateExtendedPublicKey(xpubString, network) {
  * - Must be a valid BIP32 public key.
  *
  * @param {string} pubkeyHex - (compressed) public key in hex
- * @param {string} addressType - (optional) one of P2SH, P2SH-P2WSH, P2WSH
+ * @param {string} [addressType] - one of P2SH, P2SH-P2WSH, P2WSH
  * @returns {string} empty if valid or corresponding validation message if not
  * @example
  * import {validatePublicKey} from "unchained-bitcoin";

--- a/src/keys.js
+++ b/src/keys.js
@@ -342,7 +342,7 @@ export function validateExtendedPublicKey(xpubString, network) {
  * console.log(validatePublicKey("03b32dc780fba98db25b4b72cf2b69da228f5e10ca6aa8f46eabe7f9fe22c994ee")); // ""
  * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53")); // ""
  * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53", "P2SH")); // ""
- * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53", "P2WSH")); // "P2WSH does not support uncompressed public key."
+ * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53", "P2WSH")); // "P2WSH does not support uncompressed public keys."
  */
 export function validatePublicKey(pubkeyHex, addressType) {
   if (pubkeyHex === null || pubkeyHex === undefined || pubkeyHex === "") {

--- a/src/keys.js
+++ b/src/keys.js
@@ -14,6 +14,8 @@ import assert from "assert";
 import { validateHex, toHexString, hash160 } from "./utils";
 import { bip32PathToSequence, validateBIP32Path } from "./paths";
 import { TESTNET, networkData, MAINNET } from "./networks";
+import { P2SH_P2WSH } from "./p2sh_p2wsh";
+import { P2WSH } from "./p2wsh";
 
 export const EXTENDED_PUBLIC_KEY_VERSIONS = {
   xpub: "0488b21e",
@@ -330,6 +332,7 @@ export function validateExtendedPublicKey(xpubString, network) {
  * - Must be a valid BIP32 public key.
  *
  * @param {string} pubkeyHex - (compressed) public key in hex
+ * @param {string} addressType - one of P2SH, P2SH-P2WSH, P2WSH
  * @returns {string} empty if valid or corresponding validation message if not
  * @example
  * import {validatePublicKey} from "unchained-bitcoin";
@@ -337,8 +340,11 @@ export function validateExtendedPublicKey(xpubString, network) {
  * console.log(validatePublicKey("zzzz")); // "Invalid hex..."
  * console.log(validatePublicKey("deadbeef")); // "Invalid public key."
  * console.log(validatePublicKey("03b32dc780fba98db25b4b72cf2b69da228f5e10ca6aa8f46eabe7f9fe22c994ee")); // ""
+ * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53")); // ""
+ * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53", "P2SH")); // ""
+ * console.log(validatePublicKey("04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53", "P2WSH")); // "P2WSH doesnt support uncompressed public key."
  */
-export function validatePublicKey(pubkeyHex) {
+export function validatePublicKey(pubkeyHex, addressType) {
   if (pubkeyHex === null || pubkeyHex === undefined || pubkeyHex === "") {
     return "Public key cannot be blank.";
   }
@@ -352,6 +358,14 @@ export function validatePublicKey(pubkeyHex) {
     ECPair.fromPublicKey(Buffer.from(pubkeyHex, "hex"));
   } catch (e) {
     return "Invalid public key.";
+  }
+
+  if (
+    !isKeyCompressed(pubkeyHex) &&
+    addressType &&
+    [P2SH_P2WSH, P2WSH].includes(addressType)
+  ) {
+    return `${addressType} does not support uncompressed public keys.`;
   }
 
   return "";

--- a/src/keys.test.js
+++ b/src/keys.test.js
@@ -156,39 +156,39 @@ describe("keys", () => {
       expect(validatePublicKey(uncompressedPublicKey)).toBe("");
     });
 
-    it("returns an empty string when the value is a valid compressed public key", () => {
+    it("returns an empty string when the value is a valid compressed public key used for P2SH", () => {
       expect(validatePublicKey(compressedPublicKey, P2SH)).toBe("");
     });
 
-    it("returns an empty string when the value is a valid compressed public key", () => {
+    it("returns an empty string when the value is a valid compressed public key used for P2SH-P2WSH", () => {
       expect(validatePublicKey(compressedPublicKey, P2SH_P2WSH)).toBe("");
     });
 
-    it("returns an empty string when the value is a valid compressed public key", () => {
+    it("returns an empty string when the value is a valid compressed public key used for P2WSH", () => {
       expect(validatePublicKey(compressedPublicKey, P2WSH)).toBe("");
     });
 
-    it("returns an empty string when the value is a valid uncompressed public key", () => {
+    it("returns an empty string when the value is a valid uncompressed public key used for P2SH", () => {
       expect(validatePublicKey(uncompressedPublicKey, P2SH)).toBe("");
     });
 
-    it("returns an empty string when the value is a valid uncompressed public key", () => {
+    it("returns an error message on a valid uncompressed public key used for P2SH-P2WSH", () => {
       expect(validatePublicKey(uncompressedPublicKey, P2SH_P2WSH)).toBe(
         "P2SH-P2WSH does not support uncompressed public keys."
       );
     });
 
-    it("returns an empty string when the value is a valid uncompressed public key", () => {
+    it("returns an error message on a valid uncompressed public key used for P2WSH", () => {
       expect(validatePublicKey(uncompressedPublicKey, P2WSH)).toBe(
         "P2WSH does not support uncompressed public keys."
       );
     });
 
-    it("returns an error message on a non-hex value", () => {
+    it("returns an error message on a non-hex value used for P2SH", () => {
       expect(validatePublicKey(invalidHex, P2SH)).toMatch(/invalid hex/i);
     });
 
-    it("returns an error message on an invalid value", () => {
+    it("returns an error message on an invalid value used for P2SH", () => {
       expect(validatePublicKey(invalidPublicKey, P2SH)).toMatch(
         /invalid public key/i
       );

--- a/src/keys.test.js
+++ b/src/keys.test.js
@@ -16,18 +16,21 @@ import {
   ExtendedPublicKey,
   fingerprintToFixedLengthHex,
   extendedPublicKeyRootFingerprint,
-  validateExtendedPublicKeyForNetwork,
+  validateExtendedPublicKeyForNetwork
 } from "./keys";
 
 import { TESTNET, MAINNET } from "./networks";
 
 import { TEST_FIXTURES } from "./fixtures";
 
+import { P2SH } from "./p2sh";
+import { P2SH_P2WSH } from "./p2sh_p2wsh";
+import { P2WSH } from "./p2wsh";
+
 const NODES = TEST_FIXTURES.keys.open_source.nodes;
 const extendedPubKeyNode = NODES["m/45'/0'/0'"];
 
 describe("keys", () => {
-
   describe("validateExtendedPublicKeyForNetwork", () => {
     const validXpub =
       "xpub6CCHViYn5VzKFqrKjAzSSqP8XXSU5fEC6ZYSncX5pvSKoRLrPDcF8cEaZkrQvvnuwRUXeKVjoGmAqvbwVkNBFLaRiqcdVhWPyuShUrbcZsv";
@@ -122,6 +125,13 @@ describe("keys", () => {
     });
   });
   describe("validatePublicKey", () => {
+    const invalidHex = "zzzz";
+    const invalidPublicKey = "deadbeef";
+    const compressedPublicKey =
+      "03b32dc780fba98db25b4b72cf2b69da228f5e10ca6aa8f46eabe7f9fe22c994ee";
+    const uncompressedPublicKey =
+      "04b32dc780fba98db25b4b72cf2b69da228f5e10ca6aa8f46eabe7f9fe22c994ee6e43c09d025c2ad322382347ec0f69b4e78d8e23c8ff9aa0dd0cb93665ae83d5";
+
     it("returns an error message on an empty value", () => {
       expect(validatePublicKey(undefined)).toMatch(/cannot be blank/i);
       expect(validatePublicKey("")).toMatch(/cannot be blank/i);
@@ -129,27 +139,59 @@ describe("keys", () => {
     });
 
     it("returns an error message on a non-hex value", () => {
-      expect(validatePublicKey("zzzz")).toMatch(/invalid hex/i);
+      expect(validatePublicKey(invalidHex)).toMatch(/invalid hex/i);
     });
 
     it("returns an error message on an invalid value", () => {
-      expect(validatePublicKey("deadbeef")).toMatch(/invalid public key/i);
+      expect(validatePublicKey(invalidPublicKey)).toMatch(
+        /invalid public key/i
+      );
     });
 
     it("returns an empty string when the value is a valid compressed public key", () => {
-      expect(
-        validatePublicKey(
-          "03b32dc780fba98db25b4b72cf2b69da228f5e10ca6aa8f46eabe7f9fe22c994ee"
-        )
-      ).toBe("");
+      expect(validatePublicKey(compressedPublicKey)).toBe("");
     });
 
     it("returns an empty string when the value is a valid uncompressed public key", () => {
-      expect(
-        validatePublicKey(
-          "04b32dc780fba98db25b4b72cf2b69da228f5e10ca6aa8f46eabe7f9fe22c994ee6e43c09d025c2ad322382347ec0f69b4e78d8e23c8ff9aa0dd0cb93665ae83d5"
-        )
-      ).toBe("");
+      expect(validatePublicKey(uncompressedPublicKey)).toBe("");
+    });
+
+    it("returns an empty string when the value is a valid compressed public key", () => {
+      expect(validatePublicKey(compressedPublicKey, P2SH)).toBe("");
+    });
+
+    it("returns an empty string when the value is a valid compressed public key", () => {
+      expect(validatePublicKey(compressedPublicKey, P2SH_P2WSH)).toBe("");
+    });
+
+    it("returns an empty string when the value is a valid compressed public key", () => {
+      expect(validatePublicKey(compressedPublicKey, P2WSH)).toBe("");
+    });
+
+    it("returns an empty string when the value is a valid uncompressed public key", () => {
+      expect(validatePublicKey(uncompressedPublicKey, P2SH)).toBe("");
+    });
+
+    it("returns an empty string when the value is a valid uncompressed public key", () => {
+      expect(validatePublicKey(uncompressedPublicKey, P2SH_P2WSH)).toBe(
+        "P2SH-P2WSH does not support uncompressed public keys."
+      );
+    });
+
+    it("returns an empty string when the value is a valid uncompressed public key", () => {
+      expect(validatePublicKey(uncompressedPublicKey, P2WSH)).toBe(
+        "P2WSH does not support uncompressed public keys."
+      );
+    });
+
+    it("returns an error message on a non-hex value", () => {
+      expect(validatePublicKey(invalidHex, P2SH)).toMatch(/invalid hex/i);
+    });
+
+    it("returns an error message on an invalid value", () => {
+      expect(validatePublicKey(invalidPublicKey, P2SH)).toMatch(
+        /invalid public key/i
+      );
     });
   });
 


### PR DESCRIPTION
In this small PR, we extend the functionality of the validatePublicKey function, by allowing it to accept an addressType parameter.

As we know, uncompressed public keys in general are valid public keys...
However uncompressed public keys are not valid for P2WSH and P2SH-P2WSH! 

This extension of the validatePublicKey function will be used in [THIS PR](https://github.com/unchained-capital/caravan/pull/205) to fix [THIS ISSUE](https://github.com/unchained-capital/caravan/issues/164)

NOTE: validatePublicKey will of course be backwards compatible. ie if no addressType is supplied, validatePublicKey will function as previously! The test cases confirm this.

