### PR TITLE
fix(package.json): add bip66

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@babel/polyfill": "^7.7.0",
     "bignumber.js": "^8.1.1",
     "bip32": "^2.0.5",
+    "bip66": "^1.1.5",
     "bitcoin-address-validation": "^0.2.9",
     "bitcoinjs-lib": "^5.1.10",
     "bs58check": "^2.1.2",


### PR DESCRIPTION
adds bip66 to package.json which is referenced in src/signatures.js