### PR TITLE
fix: remove module from typedef interfering with d.ts exports

### DIFF
--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -1306,7 +1306,7 @@ const TRANSACTIONS = MULTISIGS.map((test) => singleMultisigTransaction(test),
  * -   `unchained` - unchained fixtures
  * -     `nodes` -- an object mapping BIP32 paths to the corresponding [HD node]{@link module:fixtures.HDNode} derived from unchained seed phrase (not shared).
  * - `multisigs` -- an array of [multisig addresses]{@link module:fixtures.MultisigAddress} derived from the HD nodes above.
- * - `braids` -- an array of [braids]{@link module:fixtures.Braid} derived from the open_source + unchained HD nodes above.
+ * - `braids` -- an array of [braids]{@link module.braid.Braid} derived from the open_source + unchained HD nodes above.
  * - `transactions` -- an array of [transactions]{@link module:fixtures.MultisigTransaction} from the multisig address above.
  *
  * @example
@@ -1349,33 +1349,20 @@ export const TEST_FIXTURES = {
  *
  * Not all HD node fixtures have all properties below.
  *
- * @typedef module:fixtures.HDNode
+ * @typedef HDNode
  * @type {Object}
  * @property {string} pub - the (compressed) public key in hex
  * @property {string} xpub - the extended public key formatted for mainnet
  * @property {string} tpub - the extended public key formatted for testnet
  */
 
-/**
- * A braid fixture including details to build the P2SH transaction
- *
- * The particular braid included has some additional fixtures for unit tests
- *
- * @typedef module:fixtures.Braid
- * @type {Object}
- * @property {string} options.network = mainnet - mainnet or testnet
- * @property {string} options.addressType P2SH, P2SH-P2WSH, P2WSH
- * @property {ExtendedPublicKey[]} options.extendedPublicKeys ExtendedPublicKeys that make up this braid
- * @property {number} requiredSigners - how many required signers in this braid
- * @property {string} options.index - One value, relative, to add on to all xpub absolute bip32paths (0=deposit, 1=change)
- */
 
 /**
  * A multisig address fixture.  At least one of the public
  * keys in the redeem/witness script for each address is derived from
  * the BIP39 seed phrase fixture.
  *
- * @typedef module:fixtures.MultisigAddress
+ * @typedef MultisigAddress
  * @type {Object}
  * @property {module:networks.NETWORKS} network - bitcoin network
  * @property {module:multisig.MULTISIG_ADDRESS_TYPES} type - multisig address type
@@ -1394,8 +1381,8 @@ export const TEST_FIXTURES = {
  * @property {string} scriptOps - script in opcodes
  * @property {module:multisig.Multisig} multisig - `Multisig` object for address
  * @property {module:transactions.UTXO[]} utxos - UTXOs at this address
- * @property {module:fixtures.Braid} braidDetails - details to construct the braid where this Multisig address resides
- * @property {module:fixtures.Braid} changeBraidDetails - details to construct the change braid where the Change Multisig address resides (if needed)
+ * @property {module.braid.Braid} braidDetails - details to construct the braid where this Multisig address resides
+ * @property {module.braid.Braid} changeBraidDetails - details to construct the change braid where the Change Multisig address resides (if needed)
  * @property {string} psbt - unsigned psbt of the Transaction
  * @property {string} psbtPartiallySigned - psbt that has a single set of signatures inside for the open source words
  *
@@ -1415,7 +1402,7 @@ export const TEST_FIXTURES = {
  * signature(s) required to spend them cannot be produced publicly
  * (their private keys are held by Unchained Capital).
  *
- * @typedef module:fixtures.MultisigTransaction
+ * @typedef MultisigTransaction
  * @type {Object}
  * @property {string} description - describes the transaction
  * @property {module:networks.NETWORKS} network - bitcoin network

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -1,7 +1,7 @@
-/** 
+/**
  * This module provides functions for sorting & validating multisig
  * transaction inputs.
- * 
+ *
  * @module inputs
  */
 
@@ -13,28 +13,28 @@ import {multisigBraidDetails} from './multisig';
  *
  * The [`Multisig`]{@link module:multisig.MULTISIG} object represents
  * the address the corresponding UTXO belongs to.
- * 
- * @typedef module:inputs.MultisigTransactionInput
+ *
+ * @typedef MultisigTransactionInput
  * @type {Object}
  * @property {string} txid - The transaction ID where funds were received
  * @property {number} index - The index in the transaction referred to by {txid}
  * @property {module:multisig.Multisig} multisig - The multisig object encumbering this UTXO
- * 
+ *
  */
 
 /**
  * Sorts the given inputs according to the [BIP69 standard]{@link https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki#transaction-inputs}: ascending lexicographic order.
- * 
+ *
  * @param {module:inputs.MultisigTransactionInput[]} inputs - inputs to sort
  * @returns {module:inputs.MultisigTransactionInput[]} inputs sorted according to BIP69
  */
 export function sortInputs(inputs) {
   return inputs.sort((input1, input2) => {
-    if (input1.txid > input2.txid) { 
-      return 1; 
+    if (input1.txid > input2.txid) {
+      return 1;
     } else {
-      if (input1.txid < input2.txid) { 
-        return -1; 
+      if (input1.txid < input2.txid) {
+        return -1;
       } else {
         return ((input1.index < input2.index) ? -1 : 1);
       }
@@ -85,7 +85,7 @@ export function validateMultisigInputs(inputs, braidRequired) {
  *
  * @param {module:inputs.MultisigTransactionInput} input - input to validate
  * @returns {string} empty if valid or corresponding validation message if not
- * 
+ *
  */
 export function validateMultisigInput(input) {
   if (!input.txid) {
@@ -111,7 +111,7 @@ const TXID_LENGTH = 64;
  *
  * @param {string} txid - transaction ID to validate
  * @returns {string} empty if valid or corresponding validation message if not
- * 
+ *
  */
 export function validateTransactionID(txid) {
   if (txid === null || txid === undefined || txid === '') {
@@ -132,7 +132,7 @@ export function validateTransactionID(txid) {
  *
  * @param {string|number} indexString - transaction index to validate
  * @returns {string} empty if valid or corresponding validation message if not
- * 
+ *
  */
 export function validateTransactionIndex(indexString) {
   if (indexString === null || indexString === undefined || indexString === '') {

--- a/src/multisig.js
+++ b/src/multisig.js
@@ -69,7 +69,7 @@ import {payments} from "bitcoinjs-lib";
  *
  * The remaining functions accept these objects as arguments.
  *
- * @typedef module:multisig.Multisig
+ * @typedef Multisig
  * @type {Object}
  * @property {string} address - The multisig address
  * @property {Object} redeem - the redeem object from p2ms

--- a/src/psbt.js
+++ b/src/psbt.js
@@ -29,7 +29,7 @@ import {networkData} from './networks';
  * The [`Multisig`]{@link module:multisig.MULTISIG} object represents
  * the address the corresponding UTXO belongs to.
  *
- * @typedef module:inputs.MultisigTransactionPSBTInput
+ * @typedef MultisigTransactionPSBTInput
  * @type {Object}
  * @property {string} hash - The transaction ID where funds were received
  * @property {number} index - The index in the transaction referred to by {txid}
@@ -42,7 +42,7 @@ import {networkData} from './networks';
 /**
  * Represents an output in a PSBT transaction.
  *
- * @typedef module:outputs.TransactionPSBTOutput
+ * @typedef TransactionPSBTOutput
  * @type {Object}
  * @property {string} address - the output address
  * @property {number} value - output amount in Satoshis


### PR DESCRIPTION
I found that this project was having trouble getting built in typescript files (namely unchained-wallets in this case) because it would run into some namespace issues with declaration files that were generated from the jsdoc documentation. In particular it didn't like the `typedef module:...` because it would create a type of `module` that it would export from the module. 

I have to test still if this actually breaks some of the documentation generation (at worst it's probably just the linking). But I've confirmed it does allow it to get built in unchained-wallets when converting that library to typescript