### PR TITLE
key and fixture fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ lib/
 
 # misc
 .DS_Store
+.vscode

--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -199,6 +199,7 @@ const NODES = {
 
   "m/45'/1'/0'/0/0": {
     pub: "037226e92491b2cf9691152fc2e9a0a7cff8f9ab7ad1b24b6f6506d7c8bf18911b",
+    tpub: "tpubDFqzhdm1iDvKkHNwVMxFnWZjBX4m1QQK4qNELiux6RXteZdPidpymFeWFKm5koNvjTiwPZb4i456pW5JBymaCcKumuhN7DYLwX9wwGAJ71H",
     rootFingerprint: ROOT_FINGERPRINT,
   },
 
@@ -221,6 +222,7 @@ const NODES = {
 
   "m/48'/1'/0'/2'/0/0": {
     pub: "03ecf349ecf63fcd0ece9de7eb1abfb8f8b243fecc443bd62ef47744f0f6b7eef6",
+    tpub: "tpubDKVKJjFQrticLSSf77TWYmvFq6XTALifW1shoo4snhfh7YGhMHcsCB2WwvfAbQGQDJy8EwuD6kjfvYPqSxJptSKqZDvzxQFcpYy88iS85kd",
     rootFingerprint: ROOT_FINGERPRINT,
   },
 

--- a/src/keys.test.js
+++ b/src/keys.test.js
@@ -496,12 +496,12 @@ describe("keys", () => {
     it("encodes and decodes an extended public key", () => {
       const paths = ["m/45'/0'/0'", "m/45'/0'/0'/0", null];
       for (const path of paths) {
-        const { 
-          parentFingerprint, 
-          chaincode, 
-          xpub, 
-          pub: pubkey, 
-          tpub, 
+        const {
+          parentFingerprint,
+          chaincode,
+          xpub,
+          pub: pubkey,
+          tpub,
           rootFingerprint,
           depth,
           index

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -79,7 +79,7 @@ export class ExtendedPublicKey extends Struct {
   depth?: number;
   chaincode?: string;
   pubkey?: string;
-  parentFingerprint?: string;
+  parentFingerprint?: number;
   network?: NETWORKS;
   version?: KeyVersion;
   rootFingerprint?: string;
@@ -573,7 +573,7 @@ export function extendedPublicKeyRootFingerprint(extendedPublicKey: Struct): str
  * @param {string} bip32Path e.g. m/45'/0'/0
  * @param {string} pubkey pubkey to derive from
  * @param {string} chaincode chaincode corresponding to pubkey and path
- * @param {string} parentFingerprint - fingerprint of parent public key
+ * @param {number} parentFingerprint - fingerprint of parent public key
  * @param {string} network - mainnet or testnet
  * @returns {string} base58 encoded extended public key (xpub or tpub)
  */
@@ -581,7 +581,7 @@ export function deriveExtendedPublicKey(
   bip32Path: string,
   pubkey: string,
   chaincode: string,
-  parentFingerprint: string,
+  parentFingerprint: number,
   network: string = MAINNET,
 ): string {
   const xpub = new ExtendedPublicKey({


### PR DESCRIPTION
It's kind of concerning that the type conflict was able to sneak through and didn't seem to be causing many problems anywhere else. I caught it in going through the test suite where the assertion in the ExtendedPublicKey class instantiation was throwing on trying to decode the xpub. 

We also had mismatches in our test suites between paths that were being used for testnet tests using coin types that were mainnet (`0`) instead of testnet (`1`). Ledger is opinionated about that now and so was failing. I updated the caravan test suite to use the right paths [here](https://github.com/unchained-capital/caravan/commit/8ec00d9b60995f3dfb6b249ae41b550218d76aa1) but the fixtures were missing the xpubs to compare against so I added them [here](https://github.com/unchained-capital/unchained-bitcoin/commit/82251490d97aee4769b031ae505304c8ce504cf3). 

We'll want to test that the fingerprint type change doesn't break things in other environments or with other devices, but this gets things working for the ledger work so we can investigate further once everything else has stabilized. 