### PR TITLE
feat: better PsbtV2 validation to ensure proper PsbtV2s

### DIFF
--- a/src/psbtv2.test.js
+++ b/src/psbtv2.test.js
@@ -797,6 +797,15 @@ describe("PsbtV2", () => {
     );
     expect(heightLocks.length).not.toBe(0);
   });
+
+  it("Initializes Creator values when constructed without a psbt", () => {
+    const psbt = new PsbtV2();
+    expect(psbt.PSBT_GLOBAL_VERSION).toBe(2);
+    expect(psbt.PSBT_GLOBAL_TX_VERSION).toBe(2);
+    expect(psbt.PSBT_GLOBAL_INPUT_COUNT).toBe(0);
+    expect(psbt.PSBT_GLOBAL_OUTPUT_COUNT).toBe(0);
+    expect(psbt.PSBT_GLOBAL_FALLBACK_LOCKTIME).toBe(0);
+  });
 });
 
 describe("PsbtV2.nLockTime", () => {


### PR DESCRIPTION
Somewhat of a prerequisite for an `addSignature` method. Different roles have different permissions. Strictly controlling these will ensure a psbt in a valid state. This change refactors and adds some validation logic for the Creator and Constructor roles.