### PR TITLE
Bug: PsbtV2.addOuput was writing incorrect scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unchained-bitcoin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "unchained-bitcoin",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unchained-bitcoin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Unchained Capital's bitcoin utilities library.",
   "main": "lib/index.js",
   "repository": {

--- a/src/psbtv2.ts
+++ b/src/psbtv2.ts
@@ -955,11 +955,11 @@ export class PsbtV2 extends PsbtV2Maps {
     map.set(KeyType.PSBT_OUT_SCRIPT, bw.render());
 
     if (redeemScript) {
-      bw.writeBytes(script);
+      bw.writeBytes(redeemScript);
       map.set(KeyType.PSBT_OUT_REDEEM_SCRIPT, bw.render());
     }
     if (witnessScript) {
-      bw.writeBytes(script);
+      bw.writeBytes(witnessScript);
       map.set(KeyType.PSBT_OUT_WITNESS_SCRIPT, bw.render());
     }
     if (bip32Derivation) {


### PR DESCRIPTION
It should be self explanatory if you look at the diff. witness and redeem scripts were being written as script.