### PR TITLE
Fix PsbtV2.addInput, set PSBT_GLOBAL_TX_VERSION, and adjust some variable names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unchained-bitcoin",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "unchained-bitcoin",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unchained-bitcoin",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Unchained Capital's bitcoin utilities library.",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
*This is a minor version increment as it adds a breaking change on a beta lib to `PsbtV2.addInput` arguments. It also changes the function of `PsbtV2.FromV0` resulting in a PsbtV2 instance different from what it previously would have been due to the changed handling of set PSBT_GLOBAL_TX_VERSION*

This PR addresses three things: 

First, `PsbtV2.addInput()` was fixed so that it properly handles the setting of `PSBT_IN_WITNESS_UTXO`.  Previously, it was only setting this value as the witness script. Now it should be setting it as `<64-bit little endian int amount> <compact size uint scriptPubKeylen> <bytes scriptPubKey>` per BIP0174.

Second, the PSBT_GLOBAL_TX_VERSION setter was adjusted to default to 2 if a value less than 2 is passed in. Upon creation, a PsbtV2 must have a PSBT_GLOBAL_TX_VERSION gte 2. This mostly should affect `PsbtV2.FromV0` which may be passed a psbt with this value set to 1.

Third, a few badly named variables were fixed.

While this change fixes a Ledger error in Caravan's test suite to do with signing of native segwit txns, it creates a failure in the signing tests (including non-segwit) due to the txn version being updated. The text fixtures there might need to be adjusted.
