### PR TITLE
PsbtV2.PSBT_GLOBAL_TX_VERSION validation and txnv1 compatibility util

### DIFF
--- a/src/psbtv2.test.js
+++ b/src/psbtv2.test.js
@@ -913,19 +913,27 @@ describe("PsbtV2.FromV0", () => {
     (vect) => {
       for (const key in vect) {
         if (key === "hex" || key === "base64") {
-          const t = () => PsbtV2.FromV0(vect[key]);
+          const t = () => PsbtV2.FromV0(vect[key], true);
           expect(t).toThrow();
         }
       }
     }
   );
 
+  it("Throws with valid psbtv0 with PSBT_GLOBAL_TX_VERSION=1 when disallowing txnv1", () => {
+    const t = () => PsbtV2.FromV0(
+      "cHNidP8BAMUBAAAAA4RSZmhtXSRz+wmYLHLaDW1msFfD4TputL/aMEB27+dlAQAAAAD/////KgI+xaBWgfS8tWueRYhPYlqWZY4doW+ALhAuMaganq4BAAAAAP////9ErmEIocbg7uZe38fpG3ICYmN2nLh3FKmd1F24+8FD8gAAAAAA/////wIGcwQAAAAAABepFOO6EVG3Xv+/etxGc8g8j+7D3cNnh28dAAAAAAAAF6kUw01jpnIIZgcEkKjLJExr3Hzi+hOHAAAAAAABAPcCAAAAAAEBSckS0OXkb275MwOMf7fh1mXbmuVrZ/pX/kw0dqlc+VQAAAAAFxYAFADi94+YelpEk88GKZTb3knQQKki/v///wJjFBgAAAAAABepFMerbRAxgKSBgYR9NXMuk+DOmrBzh6CGAQAAAAAAF6kUhHkHLVpVDuCQC1r35wr1dVJ6h52HAkcwRAIgL1OHUuQItIF+d1HvJD7uZ9IkLKIGHo5snyKHMkfxCo0CIFtGIjFO/XM/EvxlV7wvMj/yy8FgStl6NRgH4b6Ah1vIASEC6SM19uyxhi8O6guZKX8hvbm+uaHo9BETeI9a3TBsqfzumxgAAQRHUiECqFE9mTGJbV06/IBjFI23XYhR/R/EGxCYuipqdm21Y9QhA5ON0Jvz3Snd9B8mSFisz6QLMwyY4O0nyvd3NPrAATm6Uq4iBgKoUT2ZMYltXTr8gGMUjbddiFH9H8QbEJi6Kmp2bbVj1Bj1fsZdLQAAgAEAAIBkAACAAAAAAAAAAAAiBgOTjdCb890p3fQfJkhYrM+kCzMMmODtJ8r3dzT6wAE5uhgAAAABLQAAgAEAAIBkAACAAAAAAAAAAAAAAQD3AgAAAAABAQF0Xh2qKMFwXb9z7dGD5e+RrQkY2XrT4uwsabVICG9NAAAAABcWABQrC1IrqH2xZGiYEYhgRJ/LLGna4/7///8CMpZCAAAAAAAXqRQPiU9+O3C4dB+DDgZrbvUIqfdHnYeghgEAAAAAABepFIR5By1aVQ7gkAta9+cK9XVSeoedhwJHMEQCIC3Ih+XWI72XSWgoXpyBZc+p+s2UPK8PhHLnrO9jL7lDAiBcYENAYeak5FNg07PJAanB3RSLON1sliPNj6JndYfmMgEhAjZlOGkv+5Yi51oF3CAE2F76DrwnuZlh5pTYj57eK1fK5JsYAAEER1IhAqhRPZkxiW1dOvyAYxSNt12IUf0fxBsQmLoqanZttWPUIQOTjdCb890p3fQfJkhYrM+kCzMMmODtJ8r3dzT6wAE5ulKuIgYCqFE9mTGJbV06/IBjFI23XYhR/R/EGxCYuipqdm21Y9QY9X7GXS0AAIABAACAZAAAgAAAAAAAAAAAIgYDk43Qm/PdKd30HyZIWKzPpAszDJjg7SfK93c0+sABOboYAAAAAS0AAIABAACAZAAAgAAAAAAAAAAAAAEA9wIAAAAAAQHl1qD/xfg4epDEY79hSuU2CbcpiMRK/GpXfyJma8lxpwAAAAAXFgAUKDhkidFbHN39JFtQa4/y2QmxjTb+////AqCGAQAAAAAAF6kUhHkHLVpVDuCQC1r35wr1dVJ6h52Hhs4YBQAAAAAXqRTS+wqJWOVdTGw/9Y+XD9u6MAbsB4cCRzBEAiAHpxhuavuT3nSbOpBdHHQ39HD5cJXqQQU4tqwz0VqUeAIgWmYRjH3C4U1zJaEi6wAh9U4dvV37j9VrJT+jeCcWrz0BIQP1lRzMzwCWTVTu+ngoCuCD4PDwzGOC/Sez+/3+2o3Sx7KbGAABBEdSIQKoUT2ZMYltXTr8gGMUjbddiFH9H8QbEJi6Kmp2bbVj1CEDk43Qm/PdKd30HyZIWKzPpAszDJjg7SfK93c0+sABObpSriIGAqhRPZkxiW1dOvyAYxSNt12IUf0fxBsQmLoqanZttWPUGPV+xl0tAACAAQAAgGQAAIAAAAAAAAAAACIGA5ON0Jvz3Snd9B8mSFisz6QLMwyY4O0nyvd3NPrAATm6GAAAAAEtAACAAQAAgGQAAIAAAAAAAAAAAAAAAQBHUiECGgSXRxIDRfqQF/tC2P89T7HS70yAVGhyxdpRO6vVFYUhA6AAld9INn7SHlxu3VCvQ1IxG/Bg6xAEJct69DMaoarQUq4iAgIaBJdHEgNF+pAX+0LY/z1PsdLvTIBUaHLF2lE7q9UVhRgAAAABLQAAgAEAAIBkAACAAQAAAAAAAAAiAgOgAJXfSDZ+0h5cbt1Qr0NSMRvwYOsQBCXLevQzGqGq0Bj1fsZdLQAAgAEAAIBkAACAAQAAAAAAAAAA", 
+      false
+    );
+    expect(t).toThrow();
+  });
+
   test.each(BIP_174_VECTORS_VALID_PSBT)(
     "Instantiates from BIP0174 test vectors. $case",
     (vect) => {
       for (const key in vect) {
         if (key === "hex" || key === "base64") {
-          const t = () => PsbtV2.FromV0(vect[key]);
+          const t = () => PsbtV2.FromV0(vect[key], true);
           expect(t).not.toThrow();
         }
       }
@@ -937,7 +945,7 @@ describe("PsbtV2.FromV0", () => {
       (vect) => vect.inputs !== undefined && vect.outputs !== undefined
     )
   )("Returns proper input and output counts. $case", (vect) => {
-    const psbt = PsbtV2.FromV0(vect.hex);
+    const psbt = PsbtV2.FromV0(vect.hex, true);
     expect(psbt.PSBT_GLOBAL_INPUT_COUNT).toBe(vect.inputs);
     expect(psbt.PSBT_GLOBAL_OUTPUT_COUNT).toBe(vect.outputs);
   });


### PR DESCRIPTION
For reasons, a PSBTv2 is invalid if the PSBT_GLOBAL_TX_VERSION is less than 2 (https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki#cite_note-3). This change enforces such a requirement by throwing if a Creator role (or any other role) attempts to set the value less than 2.

Other implementations may ignore this specification by allowing a PSBTv2 with PSBT_GLOBAL_TX_VERSION set to 1. Compatibility with these implementations may be desired while working with an already created and partially signed psbtV0 on txnv1. To provide this, the static `PsbtV2.FromV0` now takes a bool argument `allowTxnVersion1` which will allow for PSBT_GLOBAL_TX_VERSION to be dangerously set to 1.