### PR TITLE
Upgrade bufio to 1.2.0 for browser reads on PsbtV2.PSBT_OUT_AMOUNT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "bitcoin-address-validation": "^0.2.9",
         "bitcoinjs-lib": "^5.1.10",
         "bs58check": "^2.1.2",
-        "bufio": "^1.0.6",
+        "bufio": "^1.2.0",
         "core-js": "^2.6.10"
       },
       "devDependencies": {
@@ -4559,9 +4559,9 @@
       "dev": true
     },
     "node_modules/bufio": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.6.tgz",
-      "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.2.0.tgz",
+      "integrity": "sha512-UlFk8z/PwdhYQTXSQQagwGAdtRI83gib2n4uy4rQnenxUM2yQi8lBDzF230BNk+3wAoZDxYRoBwVVUPgHa9MCA==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -16273,9 +16273,9 @@
       "dev": true
     },
     "bufio": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.6.tgz",
-      "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.2.0.tgz",
+      "integrity": "sha512-UlFk8z/PwdhYQTXSQQagwGAdtRI83gib2n4uy4rQnenxUM2yQi8lBDzF230BNk+3wAoZDxYRoBwVVUPgHa9MCA=="
     },
     "callsites": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "bitcoin-address-validation": "^0.2.9",
     "bitcoinjs-lib": "^5.1.10",
     "bs58check": "^2.1.2",
-    "bufio": "^1.0.6",
+    "bufio": "^1.2.0",
     "core-js": "^2.6.10"
   },
   "directories": {

--- a/src/psbtv2.ts
+++ b/src/psbtv2.ts
@@ -684,7 +684,8 @@ export class PsbtV2 extends PsbtV2Maps {
       if (!value) {
         throw Error("PSBT_OUT_AMOUNT not set for an output");
       }
-      indices.push(value.readBigInt64LE());
+      const br = new BufferReader(value);
+      indices.push(br.readBigI64(value));
     }
     return indices;
   }


### PR DESCRIPTION
The bufio package supports `BufferReader.readBigI64` since version 1.2.0. This change upgrades the package and fixes the `PsbtV2.PSBT_OUT_AMOUNT` getter so that browsers can use it.