### PR TITLE
Set partialSigs from PsbtV2.FromV0

### DIFF
--- a/src/psbtv2.test.js
+++ b/src/psbtv2.test.js
@@ -655,6 +655,15 @@ const BIP_174_VECTORS_VALID_PSBT = [
       "cHNidP8BAFUCAAAAASeaIyOl37UfxF8iD6WLD8E+HjNCeSqF1+Ns1jM7XLw5AAAAAAD/////AaBa6gsAAAAAGXapFP/pwAYQl8w7Y28ssEYPpPxCfStFiKwAAAAAAAEBIJVe6gsAAAAAF6kUY0UgD2jRieGtwN8cTRbqjxTA2+uHIgIDsTQcy6doO2r08SOM1ul+cWfVafrEfx5I1HVBhENVvUZGMEMCIAQktY7/qqaU4VWepck7v9SokGQiQFXN8HC2dxRpRC0HAh9cjrD+plFtYLisszrWTt5g6Hhb+zqpS5m9+GFR25qaAQEEIgAgdx/RitRZZm3Unz1WTj28QvTIR3TjYK2haBao7UiNVoEBBUdSIQOxNBzLp2g7avTxI4zW6X5xZ9Vp+sR/HkjUdUGEQ1W9RiED3lXR4drIBeP4pYwfv5uUwC89uq/hJ/78pJlfJvggg71SriIGA7E0HMunaDtq9PEjjNbpfnFn1Wn6xH8eSNR1QYRDVb1GELSmumcAAACAAAAAgAQAAIAiBgPeVdHh2sgF4/iljB+/m5TALz26r+En/vykmV8m+CCDvRC0prpnAAAAgAAAAIAFAACAAAA=",
     inputs: 1,
     outputs: 1,
+    partialSigs: [
+      [
+        {
+          key: "0203b1341ccba7683b6af4f1238cd6e97e7167d569fac47f1e48d47541844355bd46",
+          value:
+            "304302200424b58effaaa694e1559ea5c93bbfd4a89064224055cdf070b6771469442d07021f5c8eb0fea6516d60b8acb33ad64ede60e8785bfb3aa94b99bdf86151db9a9a01",
+        },
+      ],
+    ],
   },
 
   // Case: PSBT with one P2WSH input of a 2-of-2 multisig. witnessScript,
@@ -949,6 +958,17 @@ describe("PsbtV2.FromV0", () => {
     const psbt = PsbtV2.FromV0(vect.hex, true);
     expect(psbt.PSBT_GLOBAL_INPUT_COUNT).toBe(vect.inputs);
     expect(psbt.PSBT_GLOBAL_OUTPUT_COUNT).toBe(vect.outputs);
+  });
+
+  test.each(
+    BIP_174_VECTORS_VALID_PSBT.filter((vect) => vect.partialSigs !== undefined)
+  )("Sets partialSigs when they are present. $case", (vect) => {
+    const psbt = PsbtV2.FromV0(vect.hex, true);
+    const partialSigs = psbt.PSBT_IN_PARTIAL_SIG;
+    console.log(partialSigs);
+    for (let i = 0; i < partialSigs.length; i++) {
+      expect(partialSigs[i]).toEqual(vect.partialSigs[i]);
+    }
   });
 });
 

--- a/src/psbtv2.test.js
+++ b/src/psbtv2.test.js
@@ -965,7 +965,6 @@ describe("PsbtV2.FromV0", () => {
   )("Sets partialSigs when they are present. $case", (vect) => {
     const psbt = PsbtV2.FromV0(vect.hex, true);
     const partialSigs = psbt.PSBT_IN_PARTIAL_SIG;
-    console.log(partialSigs);
     for (let i = 0; i < partialSigs.length; i++) {
       expect(partialSigs[i]).toEqual(vect.partialSigs[i]);
     }

--- a/src/psbtv2.ts
+++ b/src/psbtv2.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-shadow */
-
 /**
  * The PsbtV2 class is intended to represent an easily modifiable and
  * serializable psbt of version 2 conforming to BIP0174. Getters exist for all
@@ -36,6 +34,7 @@ type NonUniqueKeyTypeValue = { key: string; value: string | null };
 
 // These keytypes are hex bytes, but here they are used as string enums to
 // assist in Map lookups. See type Key above for more info.
+// eslint-disable-next-line no-shadow
 enum KeyType {
   PSBT_GLOBAL_XPUB = "01",
   PSBT_GLOBAL_TX_VERSION = "02",
@@ -86,12 +85,14 @@ enum KeyType {
 
 // Provided to friendly-format the PSBT_GLOBAL_TX_MODIFIABLE bitmask from
 // PsbtV2.PSBT_GLOBAL_TX_MODIFIABLE which returns PsbtGlobalTxModifiableBits[].
+// eslint-disable-next-line no-shadow
 enum PsbtGlobalTxModifiableBits {
   INPUTS = "INPUTS", // 0b00000001
   OUTPUTS = "OUTPUTS", // 0b00000010
   SIGHASH_SINGLE = "SIGHASH_SINGLE", // 0b00000100
 }
 
+// eslint-disable-next-line no-shadow
 enum SighashType {
   SIGHASH_ALL = 0x01,
   SIGHASH_NONE = 0x02,
@@ -930,9 +931,9 @@ export class PsbtV2 extends PsbtV2Maps {
     redeemScript?: Buffer;
     witnessScript?: Buffer;
     bip32Derivation?: {
-      pubkey;
-      masterFingerprint;
-      path;
+      pubkey: Buffer;
+      masterFingerprint: Buffer;
+      path: string;
     }[];
   }) {
     // TODO: Maybe this needs to check PSBT_GLOBAL_TX_MODIFIABLE before
@@ -982,8 +983,7 @@ export class PsbtV2 extends PsbtV2Maps {
       }
     }
 
-    this.inputMaps.push(map);
-    this.PSBT_GLOBAL_INPUT_COUNT = this.inputMaps.length;
+    this.PSBT_GLOBAL_INPUT_COUNT = this.inputMaps.push(map);
   }
 
   public addOutput({
@@ -1175,6 +1175,16 @@ export class PsbtV2 extends PsbtV2Maps {
         witnessScript: input.witnessScript,
         bip32Derivation: input.bip32Derivation,
       });
+
+      for (const sig of input.partialSig || []) {
+        psbtv2.addPartialSig(
+          // addInput pushes an input, so it may be safe to assume the sig
+          // belongs to the last input.
+          psbtv2.PSBT_GLOBAL_INPUT_COUNT - 1,
+          sig.pubkey,
+          sig.signature
+        );
+      }
     }
 
     let txOutputs: any = [];


### PR DESCRIPTION
Sometimes when converting from a psbtV0, valid partialsigs might already be present. This change would add them to the resultant psbtV2.