### PR TITLE
fix(fixture): missing fixture for testnet xpub export

### DIFF
--- a/src/fixtures.js
+++ b/src/fixtures.js
@@ -221,6 +221,11 @@ const NODES = {
     rootFingerprint: ROOT_FINGERPRINT,
   },
 
+  "m/45'/1'/4'/99'/2147483647/3/1": {
+    tpub: "tpubDLaKPLMBXicb8HnBkcwxCxYNqnypFd4PFhRaF1DMQu3t1qh9zscD4F7rPhkGqWJkaB4zG1gVZ4pFP14qRiEajwUPjnRg873gaPvvZYnnTnt",
+    rootFingerprint: ROOT_FINGERPRINT,
+  },
+
   // P2SH-TESTNET
   "m/45'/1'/100'": {
     xpub: "tpubDDQubdBx9cbwQtdcRTisKF7wVCwHgHewhU7wh77VzCi62Q9q81qyQeLoZjKWZ62FnQbWU8k7CuKo2A21pAWaFtPGDHP9WuhtAx4smcCxqn1",


### PR DESCRIPTION
Adding this gets uc-bitcoin back in line with Caravan test suite to cover a missing fixture that were causing some tests to fail. 
Caravan will need its dependency bumped. 

This test is currently failing:
![Screenshot 2023-03-13 at 10 22 21 AM](https://user-images.githubusercontent.com/4344978/224746974-d3e964d5-7667-4a20-bd56-2c58802c0f6d.png)
