### PR TITLE
Update bitcoin-address-validation to v2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bignumber.js": "^8.1.1",
         "bip32": "^2.0.5",
         "bip66": "^1.1.5",
-        "bitcoin-address-validation": "^0.2.9",
+        "bitcoin-address-validation": "^2.2.3",
         "bitcoinjs-lib": "^5.1.10",
         "bs58check": "^2.1.2",
         "bufio": "^1.2.0",
@@ -4362,6 +4362,14 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/base58-js": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
+      "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/bech32": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
@@ -4431,14 +4439,19 @@
       }
     },
     "node_modules/bitcoin-address-validation": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-0.2.9.tgz",
-      "integrity": "sha512-47/XSK0yCA5Ivbt0YK5wCXm82TJWQRfkEiVRQScug5DNvmLCLeUekY6gwtH4dr7Ms2m13Nktq6/dhvsjdut0xg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-2.2.3.tgz",
+      "integrity": "sha512-1uGCGl26Ye8JG5qcExtFLQfuib6qEZWNDo1ZlLlwp/z7ygUFby3IxolgEfgMGaC+LG9csbVASLcH8fRLv7DIOg==",
       "dependencies": {
-        "base-x": "^3.0.6",
-        "bech32": "^1.1.3",
-        "hash.js": "^1.1.7"
+        "base58-js": "^1.0.0",
+        "bech32": "^2.0.0",
+        "sha256-uint8array": "^0.10.3"
       }
+    },
+    "node_modules/bitcoin-address-validation/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/bitcoin-ops": {
       "version": "1.4.1",
@@ -11553,6 +11566,11 @@
         "sha.js": "bin.js"
       }
     },
+    "node_modules/sha256-uint8array": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/sha256-uint8array/-/sha256-uint8array-0.10.7.tgz",
+      "integrity": "sha512-1Q6JQU4tX9NqsDGodej6pkrUVQVNapLZnvkwIhddH/JqzBZF1fSaxSWNY6sziXBE8aEa2twtGkXUrwzGeZCMpQ=="
+    },
     "node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -15935,6 +15953,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "base58-js": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/base58-js/-/base58-js-1.0.5.tgz",
+      "integrity": "sha512-LkkAPP8Zu+c0SVNRTRVDyMfKVORThX+rCViget00xdgLRrKkClCTz1T7cIrpr69ShwV5XJuuoZvMvJ43yURwkA=="
+    },
     "bech32": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
@@ -15994,13 +16017,20 @@
       }
     },
     "bitcoin-address-validation": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-0.2.9.tgz",
-      "integrity": "sha512-47/XSK0yCA5Ivbt0YK5wCXm82TJWQRfkEiVRQScug5DNvmLCLeUekY6gwtH4dr7Ms2m13Nktq6/dhvsjdut0xg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bitcoin-address-validation/-/bitcoin-address-validation-2.2.3.tgz",
+      "integrity": "sha512-1uGCGl26Ye8JG5qcExtFLQfuib6qEZWNDo1ZlLlwp/z7ygUFby3IxolgEfgMGaC+LG9csbVASLcH8fRLv7DIOg==",
       "requires": {
-        "base-x": "^3.0.6",
-        "bech32": "^1.1.3",
-        "hash.js": "^1.1.7"
+        "base58-js": "^1.0.0",
+        "bech32": "^2.0.0",
+        "sha256-uint8array": "^0.10.3"
+      },
+      "dependencies": {
+        "bech32": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+        }
       }
     },
     "bitcoin-ops": {
@@ -21398,6 +21428,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "sha256-uint8array": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/sha256-uint8array/-/sha256-uint8array-0.10.7.tgz",
+      "integrity": "sha512-1Q6JQU4tX9NqsDGodej6pkrUVQVNapLZnvkwIhddH/JqzBZF1fSaxSWNY6sziXBE8aEa2twtGkXUrwzGeZCMpQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "bignumber.js": "^8.1.1",
     "bip32": "^2.0.5",
     "bip66": "^1.1.5",
-    "bitcoin-address-validation": "^0.2.9",
+    "bitcoin-address-validation": "^2.2.3",
     "bitcoinjs-lib": "^5.1.10",
     "bs58check": "^2.1.2",
     "bufio": "^1.2.0",

--- a/src/addresses.test.ts
+++ b/src/addresses.test.ts
@@ -3,6 +3,7 @@ import * as multisig from "./multisig";
 import { Network } from "./networks";
 
 const P2PKH = "P2PKH";
+const P2TR = "P2TR";
 
 let ADDRESSES = {};
 ADDRESSES[Network.MAINNET] = {};
@@ -12,7 +13,10 @@ ADDRESSES[Network.MAINNET][(multisig as any).P2SH] = [
 ];
 ADDRESSES[Network.MAINNET][(multisig as any).P2WSH] = [
   "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
-  "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+  "bc1qng72v5ceptk07htel0wcv6k27fkg6tmmd8887jr2l2yz5a5lnawqqeceya",
+];
+ADDRESSES[Network.MAINNET][P2TR] = [
+  "bc1pap0ck84srwp6my97h250ws73z3mq765nm2382gzcqcarx9lxjzrq4eqyp8",
 ];
 
 ADDRESSES[Network.TESTNET] = {};
@@ -23,8 +27,16 @@ ADDRESSES[Network.TESTNET][(multisig as any).P2SH] = [
 ADDRESSES[Network.TESTNET][(multisig as any).P2WSH] = [
   "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
 ];
+ADDRESSES[Network.TESTNET][P2TR] = [
+  "tb1p94dllzzcax4hs4zljaygq5trzzy79486uy72uqus24zzpkrkaeuqgfw9fy",
+];
 
-const ADDRESS_TYPES = [P2PKH, (multisig as any).P2SH, (multisig as any).P2WSH];
+const ADDRESS_TYPES = [
+  P2PKH,
+  (multisig as any).P2SH,
+  (multisig as any).P2WSH,
+  P2TR,
+];
 
 describe("addresses", () => {
   describe("validateAddress", () => {

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -2,7 +2,7 @@
  * This module provides validation messages related to addresses.
  */
 
-import bitcoinAddressValidation from "bitcoin-address-validation";
+import { validate as bitcoinAddressValidation } from "bitcoin-address-validation";
 
 import { Network } from "./networks";
 


### PR DESCRIPTION
- Update `bitcoin-address-validation` to `2.2.3`
- Adapt to new interace
- Update `addresses.test` to include a taproot example