### PR TITLE
Fix validateOutputAmount API for BigNumber

### DIFF
--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -61,7 +61,7 @@ export function validateOutput(network, output, inputsTotalSats?) {
 /**
  * Lowest acceptable output amount in Satoshis.
  */
-const DUST_LIMIT_SATS = new BigNumber(546);
+const DUST_LIMIT_SATS = "546";
 
 /**
  * Validate the given output amount (in Satoshis).
@@ -74,11 +74,15 @@ const DUST_LIMIT_SATS = new BigNumber(546);
  *
  * - Cannot exceed the total input amount (this check is only run if
  *   `inputsTotalSats` is passed.
+ *
+ *   TODO: minSats accepting a BigNumber is only to maintain some backward
+ *   compatibility. Ideally, the arg would not expose this lib's dependencies to
+ *   the caller. It should be made to only accept number or string.
  */
 export function validateOutputAmount(
   amountSats,
-  maxSats?,
-  minSats = DUST_LIMIT_SATS
+  maxSats?: number | string,
+  minSats: number | string | BigNumber = DUST_LIMIT_SATS
 ) {
   let a, its;
   try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,6 +74,8 @@ export function satoshisToBitcoins(satoshis: string | number) {
  * - Rounds down output value to the nearest Satoshi.
  */
 export function bitcoinsToSatoshis(btc: string | number) {
+  const btcAmount = new BigNumber(btc);
+
   return new BigNumber(btc)
     .shiftedBy(8)
     .integerValue(BigNumber.ROUND_DOWN)


### PR DESCRIPTION
`outputs/validateOutputAmount` is requiring a BigNumber type on its args. This leaks lib dependencies onto the caller. Previously a version of unchained-bitcoin had removed the BigNumber dependency from its API. This function must have been missed.

Unfortunately this change would require a major version increment since an arg type is updating and breaking backward compatibility.