### PR TITLE
Adjust node versions to match minimum supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.x', '16.x', '18.x']
+        node-version: ['16.x', '18.x', '20.x']
     
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.releases_created }}
       - run: npm ci


### PR DESCRIPTION
This change adjusts github workflows to match the minimum supported node version. `package.json` indicates that the minimum supported version of node is >= 16, but ci was building for 14 (incompatible) and release-please was building using 18. 

If this change is unacceptable, I would recommend alternatively `package.json` engines entry be updated to >=18 and ci strategy node versions range `['18.x', '20.x']`