### PR TITLE
Fee error types

### DIFF
--- a/src/fees.ts
+++ b/src/fees.ts
@@ -141,7 +141,7 @@ export function checkFeeRateError(feeRateSatsPerVbyte) {
  * Validate the given transaction fee rate (in Satoshis/vbyte). Returns an
  * error message if invalid. Returns empty string if valid.
  *
- * - Must be a parseable as a number.
+ * - Must be parseable as a number.
  *
  * - Cannot be negative (zero is OK).
  *

--- a/src/types/fees.ts
+++ b/src/types/fees.ts
@@ -1,0 +1,11 @@
+// eslint-disable-next-line no-shadow
+export enum FeeValidationError {
+  FEE_CANNOT_BE_NEGATIVE,
+  FEE_RATE_CANNOT_BE_NEGATIVE,
+  FEE_TOO_HIGH,
+  FEE_RATE_TOO_HIGH,
+  INPUT_AMOUNT_MUST_BE_POSITIVE,
+  INVALID_FEE,
+  INVALID_FEE_RATE,
+  INVALID_INPUT_AMOUNT,
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./keys";
 export * from "./addresses";
 export * from "./networks";
 export * from "./braid";
+export * from "./fees";


### PR DESCRIPTION
In order to provide more flexible uses for fee validation, this change introduces fee error types.

Previously, fee validation only returned strings. With validation functions which return an error type, applications using this library will be able to provide their own user feedback based on error type.

The new type `FeeValidationError` is a typescript enum collecting fee validation error categories currently being returned by `validateFee` and `validateFeeRate` functions.

To preserve backward compatibility, `validateFee` and `validateFeeRate` functions are now merely wrappers for more granular functions which return pieces of an error. These new functions are: `checkFeeError`, `checkFeeRateError`, and `getFeeErrorMessage`.

I'm not entirely happy with the naming. I think the ideal names for the more "raw" validation feedback that `checkFeeError` and `checkFeeRateError` perform would have used "validate", but validate was already used for the existing functions which return the error message. I'm open to suggestions.